### PR TITLE
backup: fix backup dir

### DIFF
--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -11,7 +11,7 @@
     systemd_timer_start_on_creation: false
     systemd_timer_script_content: |
       #!/usr/bin/env bash
-      BKP_DIR="{{ postgres_ha_cont_backup_vol }}"
+      BKP_DIR="{{ postgres_ha_cont_backup_vol }}/{{ postgres_ha_db_name }}"
       rm -vfr "${BKP_DIR}"
       /usr/bin/docker exec -i {{ postgres_ha_cont_name }} \
         pg_dump -F directory -f "/backup/{{ postgres_ha_db_name }}" \


### PR DESCRIPTION
Was removing parent `backup` dir instead of database subfolder.

This should not make things worse for keycloak nodes in theory.
They have some manually setup `/usr/local/bin/dump-keycloak-db` script:
```
#!/usr/bin/env bash
# vim: ft=sh
set -e
BKP_DIR="/docker/keycloak/backup"
DATABASES=(
  "postgres"
  "keycloak"
)
for DB in "${DATABASES[@]}"; do
  DB_DUMP_DIR="${BKP_DIR}/${DB}"
  echo "pg_dump: ${DB} > ${DB_DUMP_DIR}"
  [[ -d "${DB_DUMP_DIR}" ]] && rm -r "${DB_DUMP_DIR}"
  docker exec -i keycloak-db \
    pg_dump \
      -F directory \
      -f "/backup/${DB}" \
      -U postgres \
      "${DB}"
done
chmod 750 -R "${BKP_DIR}"
```

See also:
https://github.com/status-im/infra-role-keycloak/blob/master/tasks/backup.yml