### PR TITLE
init: create alter_system.sql on the replica as well

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,17 +12,24 @@
     - '{{ postgres_ha_cont_init_vol }}'
     - '{{ postgres_ha_cont_backup_vol }}'
 
-- name: Create dbinit SQL files
+- name: Create dbinit SQL file to create DBs
   when: postgres_ha_is_master
   template:
-    src:   '{{ item }}'
-    dest:  '{{ postgres_ha_cont_init_vol }}/{{ item | basename }}'
+    src:   'templates/init/databases.sql'
+    dest:  '{{ postgres_ha_cont_init_vol }}/databases.sql'
     owner: '{{ postgres_ha_host_uid }}'
     group: 'dockremap'
     mode:  0640
-  register: postgres_ha_init_files
-  with_fileglob:
-    - 'templates/init/*.sql'
+  register: postgres_ha_init_db
+
+- name: Create dbinit SQL file to alter system settings
+  template:
+    src:   'templates/init/alter_system.sql'
+    dest:  '{{ postgres_ha_cont_init_vol }}/alter_system.sql'
+    owner: '{{ postgres_ha_host_uid }}'
+    group: 'dockremap'
+    mode:  0640
+  register: postgres_ha_init_system
 
 - name: Install PostgreSQL client
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   when: not postgres_ha_is_master
 
 - import_tasks: reinit.yml
-  when: postgres_ha_init_files.changed
+  when: postgres_ha_init_db.changed or postgres_ha_init_system.changed
 
 - import_tasks: consul.yml
 

--- a/tasks/reinit.yml
+++ b/tasks/reinit.yml
@@ -2,7 +2,9 @@
 - name: Re-run init scripts to apply config changes
   command: |
     {{ postgres_ha_service_path }}/admin.sh -f {{ item.dest }}
-  with_items: '{{ postgres_ha_init_files.results }}'
-  when: item.changed and postgres_ha_is_master
+  loop:
+    - "{{ postgres_ha_init_system }}"
+    - "{{ postgres_ha_init_db }}"
+  when: item.changed
   loop_control:
-    label: '{{ item.dest | default("unkown") }}'
+    label: '{{ item.dest | default("unknown") }}'


### PR DESCRIPTION
The databases.sql that creates DBs should be run only on master while both master and replica(s) should have same system settings.

This is a fix for an issue we had in `data-warehouse` Postgres setup with master and replica
```
2025-08-25 09:13:52.063 UTC [1] LOG: starting PostgreSQL 15.1 on x86_64-pc-linux-musl, compiled by gcc (Alpine 12.2.1_git20220924-r4) 12.2.1 20220924, 64-bit 
2025-08-25 09:13:52.063 UTC [1] LOG: listening on IPv4 address "0.0.0.0", port 5433 
2025-08-25 09:13:52.063 UTC [1] LOG: listening on IPv6 address "::", port 5433 
2025-08-25 09:13:52.065 UTC [1] LOG: listening on Unix socket "/var/run/postgresql/.s.PGSQL.5433" 
2025-08-25 09:13:52.076 UTC [25] LOG: database system was interrupted while in recovery at log time 
2025-08-12 14:43:19 UTC 2025-08-25 09:13:52.076 UTC [25] HINT: If this has occurred more than once some data might be corrupted and you might need to choose an earlier recovery target. 
2025-08-25 09:13:52.115 UTC [25] LOG: entering standby mode 
2025-08-25 09:13:52.118 UTC [25] FATAL: recovery aborted because of insufficient parameter settings 
2025-08-25 09:13:52.118 UTC [25] DETAIL: max_connections = 100 is a lower setting than on the primary server, where its value was 200. 
2025-08-25 09:13:52.118 UTC [25] HINT: You can restart the server after making the necessary configuration changes. 2025-08-25 09:13:52.119 UTC [1] LOG: startup process (PID 25) exited with exit code 1 
2025-08-25 09:13:52.119 UTC [1] LOG: aborting startup due to startup process failure 
2025-08-25 09:13:52.120 UTC [1] LOG: database system is shut down
```